### PR TITLE
 GEN     ./Makefile   HOSTCC  scripts/basic/fixdep clang-14: error: u…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -298,6 +298,7 @@ HOSTCC       = gcc
 HOSTCXX      = g++
 HOSTCFLAGS   = -Wall -Wmissing-prototypes -Wstrict-prototypes -O2 -fomit-frame-pointer -std=gnu89
 HOSTCXXFLAGS = -O2
+HOSTLDFLAGS  += $(HOST_LFS_LDFLAGS)
 
 ifeq ($(shell $(HOSTCC) -v 2>&1 | grep -c "clang version"), 1)
 HOSTCFLAGS  += -Wno-unused-value -Wno-unused-parameter \
@@ -358,6 +359,8 @@ CPP		= $(CC) -E
 AR		= $(CROSS_COMPILE)ar
 NM		= $(CROSS_COMPILE)nm
 STRIP		= $(CROSS_COMPILE)strip
+HOSTLDFLAGS	+= -fuse-ld=lld
+HOSTCFLAGS	+= -fuse-ld=lld
 OBJCOPY		= $(CROSS_COMPILE)objcopy
 OBJDUMP		= $(CROSS_COMPILE)objdump
 AWK		= awk


### PR DESCRIPTION
…nable to execute command: Executable "ld" doesn't exist! clang-14: error: linker command failed with exit code 1 (use -v to see invocation) make[2]: *** [scripts/Makefile.host:102: scripts/basic/fixdep] Error 1